### PR TITLE
Upgrade `tokio` example to use version 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ futures-timer = "2.0.0"
 
 [dev-dependencies]
 futures = { version = "0.3.1", features = ["compat"]}
-tokio = "0.1"
+tokio = "0.2"

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -29,7 +29,7 @@ fn main() {
             .load(4)
             .and_then(move |v| loader2.load_many(vec![v, v + 5, v + 10]));
         let all = future::try_join(v1, v2);
-        let output = rt.block_on(all.boxed().compat()).unwrap();
+        let output = rt.block_on(all).unwrap();
         let expected = (vec![300, 350, 400], vec![400, 450, 500]);
         assert_eq!(expected, output);
     }
@@ -46,7 +46,7 @@ fn main() {
             .load(4)
             .and_then(move |v| ld2.load_many(vec![v, v + 5, v + 10]));
         let all = future::try_join(v1, v2);
-        let output = rt.block_on(all.boxed().compat()).unwrap();
+        let output = rt.block_on(all).unwrap();
         let expected = (vec![300, 350, 400], vec![400, 450, 500]);
         assert_eq!(expected, output);
     }


### PR DESCRIPTION
Just saw a quick opportunity to take advantage of the newer version of `tokio` and clean up the code slightly. Thanks so much for writing and maintaining this lib!