### PR TITLE
feature request : BatchFn::load function takes &mut self instead of &self

### DIFF
--- a/examples/async_graphql.rs
+++ b/examples/async_graphql.rs
@@ -12,7 +12,7 @@ pub struct CultBatcher;
 
 #[async_trait]
 impl BatchFn<i32, Cult> for CultBatcher {
-    async fn load(&self, keys: &[i32]) -> HashMap<i32, Cult> {
+    async fn load(&mut self, keys: &[i32]) -> HashMap<i32, Cult> {
         println!("load cult by batch {:?}", keys);
         let ret = keys
             .iter()

--- a/examples/cached.rs
+++ b/examples/cached.rs
@@ -9,7 +9,7 @@ struct MyLoadFn;
 
 #[async_trait]
 impl BatchFn<usize, usize> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         println!("BatchFn load keys {:?}", keys);
         keys.iter()
             .map(|v| (v.clone(), v.clone()))

--- a/examples/juniper.rs
+++ b/examples/juniper.rs
@@ -12,7 +12,7 @@ pub struct CultBatcher;
 
 #[async_trait]
 impl BatchFn<i32, Cult> for CultBatcher {
-    async fn load(&self, keys: &[i32]) -> HashMap<i32, Cult> {
+    async fn load(&mut self, keys: &[i32]) -> HashMap<i32, Cult> {
         println!("load cult by batch {:?}", keys);
         let ret = keys
             .iter()

--- a/examples/non_cached.rs
+++ b/examples/non_cached.rs
@@ -9,7 +9,7 @@ struct MyLoadFn;
 
 #[async_trait]
 impl BatchFn<usize, usize> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         println!("BatchFn load keys {:?}", keys);
         keys.iter()
             .map(|v| (v.clone(), v.clone()))

--- a/src/batch_fn.rs
+++ b/src/batch_fn.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 #[async_trait]
 pub trait BatchFn<K, V> {
-    async fn load(&self, keys: &[K]) -> HashMap<K, V>
+    async fn load(&mut self, keys: &[K]) -> HashMap<K, V>
     where
         K: 'async_trait,
         V: 'async_trait;

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -143,7 +143,7 @@ where
             state.pending.insert(key.clone());
             if state.pending.len() >= self.max_batch_size {
                 let keys = state.pending.drain().collect::<Vec<K>>();
-                let load_fn = self.load_fn.lock().await;
+                let mut load_fn = self.load_fn.lock().await;
                 let load_ret = load_fn.load(keys.as_ref()).await;
                 drop(load_fn);
                 for (k, v) in load_ret.into_iter() {
@@ -172,7 +172,7 @@ where
 
         if !state.pending.is_empty() {
             let keys = state.pending.drain().collect::<Vec<K>>();
-            let load_fn = self.load_fn.lock().await;
+            let mut load_fn = self.load_fn.lock().await;
             let load_ret = load_fn.load(keys.as_ref()).await;
             drop(load_fn);
             for (k, v) in load_ret.into_iter() {
@@ -200,7 +200,7 @@ where
                 state.pending.insert(key.clone());
                 if state.pending.len() >= self.max_batch_size {
                     let keys = state.pending.drain().collect::<Vec<K>>();
-                    let load_fn = self.load_fn.lock().await;
+                    let mut load_fn = self.load_fn.lock().await;
                     let load_ret = load_fn.load(keys.as_ref()).await;
                     drop(load_fn);
                     for (k, v) in load_ret.into_iter() {
@@ -223,7 +223,7 @@ where
             let mut state = self.state.lock().await;
             if !state.pending.is_empty() {
                 let keys = state.pending.drain().collect::<Vec<K>>();
-                let load_fn = self.load_fn.lock().await;
+                let mut load_fn = self.load_fn.lock().await;
                 let load_ret = load_fn.load(keys.as_ref()).await;
                 drop(load_fn);
                 for (k, v) in load_ret.into_iter() {

--- a/src/non_cached.rs
+++ b/src/non_cached.rs
@@ -95,7 +95,7 @@ where
                 .collect::<HashSet<K>>()
                 .into_iter()
                 .collect();
-            let load_fn = self.load_fn.lock().await;
+            let mut load_fn = self.load_fn.lock().await;
             let load_ret = load_fn.load(keys.as_ref()).await;
             drop(load_fn);
             for (request_id, key) in batch.into_iter() {
@@ -129,7 +129,7 @@ where
                     .collect::<HashSet<K>>()
                     .into_iter()
                     .collect();
-                let load_fn = self.load_fn.lock().await;
+                let mut load_fn = self.load_fn.lock().await;
                 let load_ret = load_fn.load(keys.as_ref()).await;
                 drop(load_fn);
                 for (request_id, key) in batch.into_iter() {
@@ -162,7 +162,7 @@ where
                     .collect::<HashSet<K>>()
                     .into_iter()
                     .collect();
-                let load_fn = self.load_fn.lock().await;
+                let mut load_fn = self.load_fn.lock().await;
                 let load_ret = load_fn.load(keys.as_ref()).await;
                 drop(load_fn);
                 for (request_id, key) in batch.into_iter() {
@@ -206,7 +206,7 @@ where
                     .collect::<HashSet<K>>()
                     .into_iter()
                     .collect();
-                let load_fn = self.load_fn.lock().await;
+                let mut load_fn = self.load_fn.lock().await;
                 let load_ret = load_fn.load(keys.as_ref()).await;
                 drop(load_fn);
                 for (request_id, key) in batch.into_iter() {

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -10,7 +10,7 @@ struct MyLoadFn;
 
 #[async_trait]
 impl BatchFn<usize, usize> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         keys.iter()
             .map(|v| (v.clone(), v.clone()))
             .collect::<HashMap<_, _>>()
@@ -22,7 +22,7 @@ struct Object(usize);
 
 #[async_trait]
 impl BatchFn<usize, Object> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, Object> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, Object> {
         keys.iter()
             .map(|v| (v.clone(), Object(v.clone())))
             .collect::<HashMap<_, _>>()
@@ -51,7 +51,7 @@ struct LoadFnWithHistory<K> {
 
 #[async_trait]
 impl BatchFn<usize, usize> for LoadFnWithHistory<usize> {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         // println!("BatchFn load keys {:?}", keys);
         let mut loaded_keys = self.loaded_keys.lock().unwrap();
         let mut max_batch_loaded = self.max_batch_loaded.lock().unwrap();

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -34,7 +34,7 @@ impl<T> BatchFn<ObjectId, Option<T>> for ModelBatcher
 where
     T: Model,
 {
-    async fn load(&self, keys: &[ObjectId]) -> HashMap<ObjectId, Option<T>>
+    async fn load(&mut self, keys: &[ObjectId]) -> HashMap<ObjectId, Option<T>>
     where
         T: 'async_trait,
     {

--- a/tests/non_cached.rs
+++ b/tests/non_cached.rs
@@ -10,7 +10,7 @@ struct MyLoadFn;
 
 #[async_trait]
 impl BatchFn<usize, usize> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         keys.iter()
             .map(|v| (v.clone(), v.clone()))
             .collect::<HashMap<_, _>>()
@@ -22,7 +22,7 @@ struct Object(usize);
 
 #[async_trait]
 impl BatchFn<usize, Object> for MyLoadFn {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, Object> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, Object> {
         keys.iter()
             .map(|v| (v.clone(), Object(v.clone())))
             .collect::<HashMap<_, _>>()
@@ -50,7 +50,7 @@ struct LoadFnWithHistory {
 
 #[async_trait]
 impl BatchFn<usize, usize> for LoadFnWithHistory {
-    async fn load(&self, keys: &[usize]) -> HashMap<usize, usize> {
+    async fn load(&mut self, keys: &[usize]) -> HashMap<usize, usize> {
         // println!("BatchFn load keys {:?}", keys);
         let mut max_batch_loaded = self.max_batch_loaded.lock().unwrap();
         if keys.len() > *max_batch_loaded {


### PR DESCRIPTION
I love to use this crate! Thanks for creating!

## Added feature

`BatchFn::load` function now able to take `&mut self` parameter. It brings more flexibility.

## Why I need this

The `BatchFn::load` function needs to be mutable when I use `tokio-postgres` with this since [`Client::transaction`](https://docs.rs/tokio-postgres/0.6.0/tokio_postgres/struct.Client.html#method.transaction) function requires `&mut self`.
Maybe we can use `Mutex` but it seems to me that `BatchFn` could easily be mutable.

## Breaking change

The signature of `BatchFn::load` function is changed.

Thanks for reading!