### PR TITLE
add missing tokio features in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ runtime-tokio = [
 [dependencies]
 async-trait = "0.1"
 async-std = { version = "1.0", optional = true }
-tokio = { version = "0.3", optional = true }
+tokio = { version = "0.3", features = [ "sync", "rt" ], optional = true }
 
 [dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
feature "runtime-tokio" does not compile because of missing features used in runtime.rs.  They have been added in.