### PR TITLE
chore: update dependencies to use tokio 1.0 and async-std 1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ runtime-tokio = [
 
 [dependencies]
 async-trait = "0.1"
-async-std = { version = "1.0", optional = true }
-tokio = { version = "0.3", features = [ "sync", "rt" ], optional = true }
+async-std = { version = "1.8", optional = true }
+tokio = { version = "1.0", features = [ "sync", "rt" ], optional = true }
 
 [dev-dependencies]
 futures = "0.3"
-fake = { version = "2.2", features = ["derive"] }
+fake = { version = "2.3", features = ["derive"] }
 rand = "0.7"
 juniper = "0.15.0"
-async-graphql = { version = "2.1.7", default-features = false }
+async-graphql = { version = "2.4", default-features = false }
 serde_json = "1.0"
 


### PR DESCRIPTION
- update dependencies to utilize tokio 1.0 and async-std 1.8

note - I attempted updating rand to 0.8 but that is a [bit more involved](https://rust-random.github.io/book/update-0.8.html) so let that out of this PR and will save for a separate PR