### PR TITLE
Add load_safe & load_many_safe which return resulted values

### DIFF
--- a/src/non_cached.rs
+++ b/src/non_cached.rs
@@ -84,7 +84,7 @@ impl<K, V, F> Loader<K, V, F>
         self.max_batch_size
     }
 
-    pub async fn load_safe(&self, key: K) -> Result<V, Error> {
+    pub async fn try_load(&self, key: K) -> Result<V, Error> {
         let mut state = self.state.lock().await;
         let request_id = state.next_request_id();
         state.pending.insert(request_id, key);
@@ -148,14 +148,14 @@ impl<K, V, F> Loader<K, V, F>
     }
 
     pub async fn load(&self, key: K) -> V {
-        self.load_safe(key).await.unwrap_or_else(|e| panic!("{}", e))
+        self.try_load(key).await.unwrap_or_else(|e| panic!("{}", e))
     }
 
     pub async fn load_many(&self, keys: Vec<K>) -> HashMap<K, V> {
-        self.load_many_safe(keys).await.unwrap_or_else(|e| panic!("{}", e))
+        self.try_load_many(keys).await.unwrap_or_else(|e| panic!("{}", e))
     }
 
-    pub async fn load_many_safe(&self, keys: Vec<K>) -> Result<HashMap<K, V>, Error> {
+    pub async fn try_load_many(&self, keys: Vec<K>) -> Result<HashMap<K, V>, Error> {
         let mut state = self.state.lock().await;
         let mut ret = HashMap::new();
         let mut requests = Vec::new();

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -179,7 +179,7 @@ fn test_load_safe_unresolved_key() {
     let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
 
     let h1 = thread::spawn(move || {
-        let r1 = loader.load_safe(1337);
+        let r1 = loader.try_load(1337);
         let fv = block_on(r1);
 
         assert!(fv.is_err())

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -4,7 +4,7 @@ use dataloader::BatchFn;
 use futures::executor::block_on;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::{thread, panic};
 
 struct MyLoadFn;
 
@@ -70,6 +70,16 @@ impl BatchFn<usize, usize> for LoadFnWithHistory<usize> {
                 (v.clone(), v.clone())
             })
             .collect::<HashMap<_, _>>()
+    }
+}
+
+#[derive(Clone)]
+struct LoadFnForEmptyTest;
+
+#[async_trait]
+impl BatchFn<usize, usize> for LoadFnForEmptyTest {
+    async fn load(&mut self, _keys: &[usize]) -> HashMap<usize, usize> {
+        HashMap::new()
     }
 }
 
@@ -145,6 +155,37 @@ fn test_load() {
             max_batch_size
         );
     }
+}
+
+#[test]
+#[should_panic(expected = "could not lookup result for given key: 1337")]
+fn test_load_unresolved_key() {
+    let load_fn = LoadFnForEmptyTest;
+    let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
+
+    let h1 = thread::spawn(move || {
+        let r1 = loader.load(1337);
+        block_on(r1);
+    });
+
+    let _ = h1.join().map_err(|e| {
+        panic::resume_unwind(e)
+    });
+}
+
+#[test]
+fn test_load_safe_unresolved_key() {
+    let load_fn = LoadFnForEmptyTest;
+    let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
+
+    let h1 = thread::spawn(move || {
+        let r1 = loader.load_safe(1337);
+        let fv = block_on(r1);
+
+        assert!(fv.is_err())
+    });
+
+    let _ = h1.join().unwrap();
 }
 
 #[test]

--- a/tests/non_cached.rs
+++ b/tests/non_cached.rs
@@ -166,7 +166,7 @@ fn test_load_safe_unresolved_key() {
     let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
 
     let h1 = thread::spawn(move || {
-        let r1 = loader.load_safe(1337);
+        let r1 = loader.try_load(1337);
         let fv = block_on(r1);
 
         assert!(fv.is_err())

--- a/tests/non_cached.rs
+++ b/tests/non_cached.rs
@@ -4,7 +4,7 @@ use dataloader::BatchFn;
 use futures::executor::block_on;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::{thread, panic};
 
 struct MyLoadFn;
 
@@ -59,6 +59,16 @@ impl BatchFn<usize, usize> for LoadFnWithHistory {
         keys.iter()
             .map(|v| (v.clone(), v.clone()))
             .collect::<HashMap<_, _>>()
+    }
+}
+
+#[derive(Clone)]
+struct LoadFnForEmptyTest;
+
+#[async_trait]
+impl BatchFn<usize, usize> for LoadFnForEmptyTest {
+    async fn load(&mut self, _keys: &[usize]) -> HashMap<usize, usize> {
+        HashMap::new()
     }
 }
 
@@ -132,6 +142,37 @@ fn test_load() {
             max_batch_size
         );
     }
+}
+
+#[test]
+#[should_panic(expected = "could not lookup result for given key: 1337")]
+fn test_load_unresolved_key() {
+    let load_fn = LoadFnForEmptyTest;
+    let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
+
+    let h1 = thread::spawn(move || {
+        let r1 = loader.load(1337);
+        block_on(r1);
+    });
+
+    let _ = h1.join().map_err(|e| {
+        panic::resume_unwind(e)
+    });
+}
+
+#[test]
+fn test_load_safe_unresolved_key() {
+    let load_fn = LoadFnForEmptyTest;
+    let loader = Loader::new(load_fn.clone()).with_max_batch_size(4);
+
+    let h1 = thread::spawn(move || {
+        let r1 = loader.load_safe(1337);
+        let fv = block_on(r1);
+
+        assert!(fv.is_err())
+    });
+
+    let _ = h1.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
I stumbled upon the error *"found key {:?} in load result"* and so i thought it might be useful to have additional "Resulted" alternative of `load` and `load_many` so one has the chance to handle it outside of the dataloader